### PR TITLE
Catch KeyErrors when finding interactions and try to fetch them from …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if os.path.isfile(requirement_path):
 if __name__ == "__main__":
     setup(
         name='skynamo',
-        version='0.0.24',
+        version='0.0.25',
         author='Daniel van Niekerk',
         author_email='daniel@skynamo.com',
         description='Skynamo Public API SDK',

--- a/skynamo/reader/jsonToObjects.py
+++ b/skynamo/reader/jsonToObjects.py
@@ -2,10 +2,16 @@ import json
 from ..models.Transaction import Transaction
 from ..models.Address import Address
 from ..shared.helpers import getDateTimeObjectFromSkynamoDateTimeStr
+from ..shared.api import makeRequest
 from typing import List
 
 def populateUserIdAndNameFromInteractionAndReturnFormIds(transaction:Transaction,interactionsJson:dict):
-	interaction=interactionsJson['items'][str(transaction.interaction_id)]
+	try:
+		interaction=interactionsJson['items'][str(transaction.interaction_id)]
+	except KeyError:
+		interaction = makeRequest('get', f'interactions/{transaction.interaction_id}')
+		if interaction.errors:
+			raise KeyError(transaction.interaction_id)
 	transaction.user_id=interaction['user_id']
 	transaction.user_name=interaction['user_name']
 	formIds=[]


### PR DESCRIPTION
…the API

This is due to some key errors we've seen. They seem to clear up after a while so this is just a stop-gap while waiting for that to happen.